### PR TITLE
added an error message for empty searches(Default action for search bar)Issue #5371 

### DIFF
--- a/app/templates/gentelella/components/menu.html
+++ b/app/templates/gentelella/components/menu.html
@@ -22,7 +22,7 @@
                             <input type="hidden" name="location" value="">
                             <input type="hidden" name="category" value="">
                             <div class="input-group" style="margin-top:12px; margin-bottom:6px">
-                                <input type="text" id="search-text" class="form-control" name="query"
+                                <input type="text" id="search-text" class="form-control" name="query" required
                                        placeholder="Search for..."/>
                                 <span class="input-group-btn">
                                 <button class="btn btn-default search-button" type="submit">


### PR DESCRIPTION
<!-- 
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)
-->

#### Checklist

- [X] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [X] My branch is up-to-date with the Upstream `development` branch.
- [X] The unit tests pass locally with my changes <!-- use `nosetests tests/unittests` to run all the tests -->
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

#### Short description of what this resolves:

Clicking on search,without entering any text redirects to "https://eventyay.com/explore/united-states/events/" 

#### Changes proposed in this pull request:

-shows a small error message if the box is empty
-
-
![myfirstissue](https://user-images.githubusercontent.com/27897288/45827958-1e976000-bd15-11e8-80ae-75949b39dae8.png)


<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

Fixes #5371
